### PR TITLE
Optional copy code button

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,8 @@
 # Changelog for plasmic-render-markdown
 
+### 0.1.1 -> 0.1.2 (05 July 2024)
+* Added prop to `RenderMarkdown` called `showCopshowCopyCodeBtnsInCodeBlocks`. This allows the user to choose whether copy code buttons are shown in codeblocks within the rendered markdown.
+
 ### 0.1.0 -> 0.1.1 (21 May 2024)
 * Updated readme to include instruction for codegen.
 

--- a/lib/components/RenderMarkdown/index.tsx
+++ b/lib/components/RenderMarkdown/index.tsx
@@ -17,6 +17,7 @@ export type RenderMarkdownProps = {
   dangerouslyRenderHtmlTags?: boolean;
   autoGenerateTableOfContents?: boolean;
   inputTextIsEncoded?: boolean;
+  showCopyCodeBtnsInCodeBlocks?: boolean;
   className?: string;
 };
 
@@ -25,6 +26,7 @@ export function RenderMarkdown({
   dangerouslyRenderHtmlTags = false,
   autoGenerateTableOfContents = false,
   inputTextIsEncoded = false,
+  showCopyCodeBtnsInCodeBlocks = true,
   className = "",
 }: RenderMarkdownProps) {
   
@@ -38,12 +40,12 @@ export function RenderMarkdown({
   const remarkPlugins = autoGenerateTableOfContents ? [remarkGfm, remarkToc] : [remarkGfm];
   const rehypePlugins = [
     rehypeHighlight,
-    rehypeAddCopyButton,
+    ...(showCopyCodeBtnsInCodeBlocks ? [rehypeAddCopyButton] : []),
     ...(autoGenerateTableOfContents ? [rehypeSlug] : []),
     ...(dangerouslyRenderHtmlTags ? [rehypeRaw] : [])
   ];
 
-  //Make the "copy code" buttons work
+  //Make the "copy code" buttons work (if present)
   useEffect(() => {
     const handleCopy = (event: Event) => {
       const buttonElement = event.currentTarget as HTMLButtonElement;

--- a/lib/components/RenderMarkdown/registerComponentMeta.tsx
+++ b/lib/components/RenderMarkdown/registerComponentMeta.tsx
@@ -25,6 +25,11 @@ export const renderMarkdownMeta: CodeComponentMeta<RenderMarkdownProps> = {
       description: 'Whether the markdownText prop is URI encoded. If true, the markdownText prop will be decoded before rendering. If false, the markdownText prop will be rendered as is.',
       defaultValue: false
     },
+    showCopyCodeBtnsInCodeBlocks: {
+      type: "boolean",
+      description: "Show copy code buttons in code blocks?",
+      defaultValue: true
+    },
     className: {
       type: "class",
       selectors: [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plasmic-render-markdown",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "type": "module",
   "main": "dist/main.js",
   "types": "dist/main.d.ts",


### PR DESCRIPTION
Allowing users to specify whether the copy code button appears within codeblocks in rendered markdown.